### PR TITLE
Pin monaco vscode to 3.2.3 and add dontNpmPrune

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,6 +14,7 @@ buildNpmPackage {
 
   npmDeps = importNpmLock { npmRoot = ./..; };
   inherit (importNpmLock) npmConfigHook;
+  dontNpmPrune = true;
 
   preBuild = ''
     npm run langium:generate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "crill-ios-scripting",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "crill-ios-scripting",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "dependencies": {
                 "@codingame/monaco-vscode-editor-service-override": "3.2.3",
                 "@codingame/monaco-vscode-keybindings-service-override": "3.2.3",
@@ -189,12 +189,184 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
             "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
             }
         },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
@@ -206,12 +378,193 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
             "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
             }
         },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
@@ -222,6 +575,92 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
@@ -230,12 +669,200 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
             "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-configuration-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/@codingame/monaco-vscode-editor-service-override": {
@@ -309,12 +936,694 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
             "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-languages-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/@codingame/monaco-vscode-layout-service-override": {
@@ -333,12 +1642,1394 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
+            "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-localization-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-model-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-4.3.2.tgz",
             "integrity": "sha512-0XUfT+hHQ9tFqcamssSDr1/6S74MBlWx9aPjE2iOmeqWst8CIrEZDz2FF8MLJyrOlPDULF8v+LII76S7bgVg4g==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
+            "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-model-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
@@ -360,6 +3051,301 @@
                 "vscode-textmate": "9.0.0"
             }
         },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
@@ -368,12 +3354,1090 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-textmate-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-4.3.2.tgz",
             "integrity": "sha512-+bvLMk6RrwxOFIZu8J9QDGZf5Tq5XhXBmheZl7ib+sVXFReKWzOS7q41rq/pvK/EHCPn9HBTG11XbeIO/VoM2g==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
+            "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/@codingame/monaco-vscode-theme-service-override": {
@@ -385,12 +4449,694 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
         "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
             "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/@codingame/monaco-vscode-theme-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -3636,6 +8382,19 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -3743,12 +8502,773 @@
                 }
             }
         },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-4.3.2.tgz",
             "integrity": "sha512-2GdLebFY5Ghs3mFKnsyYqGuSikK1nsYxWvU3E0zy+H2Xlk1xVoHNYv375FJlQmtmYbxKYwfWp2J4QSE6kThKkQ==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-editor-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
+            "integrity": "sha512-Q6equ0J2Jp13RTggCpif4jRLmHm9TocQVZVPXziXdQTg983ShFBq2C0RkGGIz/BPfVr1Kw3T0RRoFbsQJF7XVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-4.3.2.tgz",
+            "integrity": "sha512-18GqmWAntZ0UcW2CgSqHjqOa3afhLC0crVPg9jsa8SjgH0RXEs633QS0OLhtr36wkiOarQrW/IM75mhyZQTn8w==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
             }
         },
         "node_modules/monaco-editor-wrapper/node_modules/@esbuild/aix-ppc64": {
@@ -4142,6 +9662,108 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/monaco-editor/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-editor-wrapper/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
+            }
+        },
         "node_modules/monaco-languageclient": {
             "version": "8.3.1",
             "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-8.3.1.tgz",
@@ -4172,6 +9794,196 @@
                 }
             }
         },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-4.3.2.tgz",
+            "integrity": "sha512-P70WtCyw+stZRN8U9degYBYy4jnfyWZuUoG/ZxoFIeZLvMnm4mRbTfINJ/fyD3Km5NzJJe4lwoAXmNC0dFfYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-base-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-4.3.2.tgz",
+            "integrity": "sha512-2lYv4ruLnBcfPfdVqUpz9u6qlkMLqBr7BN0CEQyi4WzSnpQKk4aPZ+fZrOsZ1WbaHiG5gav0GEyIzZnIQUzWwg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-environment-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-4.3.2.tgz",
@@ -4179,6 +9991,101 @@
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "4.3.2",
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-extensions-service-override/node_modules/vscode/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
             }
         },
         "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override": {
@@ -4189,6 +10096,377 @@
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
             }
         },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-files-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-4.3.2.tgz",
+            "integrity": "sha512-NuOZchA7yuUqznsw9Bu2BV5DmakPeMVUHQ5Gc9n6h4GWM9LwdmGYfcuV4PysV3fLN5ezbYDsfZZH8Ny1RvOCrg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-host-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-4.3.2.tgz",
+            "integrity": "sha512-q3+ilh2bneZc3ymDAx5WP6pERoA2pgWXu3zWYwp8GxCX9p9hkIz7hl8BSfh9brekJHhWDLCxeWlmPXZ2mdXVsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-layout-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-4.3.2.tgz",
+            "integrity": "sha512-+8uYpHbIt54EptAkJEptt1EJWNLrQ8HATB317NPsdqjkoqZYenijtwL5kZRHtKvV81QTdFDvkT09Zv5Hq4eSRw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/@codingame/monaco-vscode-quickaccess-service-override/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
         "node_modules/monaco-languageclient/node_modules/monaco-editor": {
             "name": "@codingame/monaco-vscode-editor-api",
             "version": "4.3.2",
@@ -4196,6 +10474,108 @@
             "integrity": "sha512-HDNx4cG2tnGe3gVZhz/r/1YCDuzMeBzplylY8BeAuKldSE5AwoaK4Q81wV85mGYmzy1Ra0Az75pKUPKnSC3ZMg==",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@4.3.2"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-base-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-3.2.3.tgz",
+            "integrity": "sha512-OHVtyMIbcFPC68Fv6jEg7p7MYIK9UzymnbwPRetuOHFj1xMALI7qkl9DH0czBBOZAk+4BttXqZLlJ9Ph3B4HHg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-environment-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-3.2.3.tgz",
+            "integrity": "sha512-7YVJhS0RuKkrjwzz2ZKJeU98t29Yc2U/NfQfpTTbLfnZVBxPnC4Gbm59bRWswjtbBrIVpO5Dil+00o32HwXzyw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-3.2.3.tgz",
+            "integrity": "sha512-YZfEmKaXyXh54rIJ/c9k+D1JeWfHiryW5UfuVgscmLS3QoiLsPRurfVBY4zIBN88rTQknOViqqW7llpnmaiFYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3",
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-files-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-3.2.3.tgz",
+            "integrity": "sha512-M/yEyD4zSYt7eQISeH/OSUELxx7nXtmXIHjC9mQXBo0VD47nAgjy9Yo3vS1al3+Sz3j1Uj2je96x/6Q9zGwg4A==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-host-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-3.2.3.tgz",
+            "integrity": "sha512-zY54k4czioGczMOmWPF6aHx7jrHSnkU1D36MYyY3wrvFgI5diJCrCSz35VPf0WTlLh4OT1jJ+D9ufmJ1cn1moQ==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-layout-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-3.2.3.tgz",
+            "integrity": "sha512-ZMSjElmJdvMb4C7TJe71QJXvn4EZ8YvDGCNChuUHmbGfaX2MEmtMBvMjZH+z5RF5IA1Mtx6RztSBJHDhhYgjBA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-3.2.3.tgz",
+            "integrity": "sha512-vr6l1tvA81yOfYKG5zdCaMoGeE7ruWXfISeQv8XcHpr1/VvxCdeBOi22GhRaomEKg9ioAqxzAe0WK8cS96ftIA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/monaco-editor/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-3.2.3.tgz",
+            "integrity": "sha512-YOad82N2G5Ae/Ry14LOM3Mka6EjzbGXfwIs44xP/kFdhk9m7c1vXiIQxJIyUjTsJgzfEqYvcQKULlt4cqC7cEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "3.2.3",
+                "@codingame/monaco-vscode-environment-service-override": "3.2.3",
+                "@codingame/monaco-vscode-extensions-service-override": "3.2.3",
+                "@codingame/monaco-vscode-files-service-override": "3.2.3",
+                "@codingame/monaco-vscode-host-service-override": "3.2.3",
+                "@codingame/monaco-vscode-layout-service-override": "3.2.3",
+                "@codingame/monaco-vscode-quickaccess-service-override": "3.2.3"
+            }
+        },
+        "node_modules/monaco-languageclient/node_modules/vscode": {
+            "name": "@codingame/monaco-vscode-api",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-4.3.2.tgz",
+            "integrity": "sha512-tm6ziBqxQWekk2e9WiKeY1FE1BTNA9Ky1pvLudpyXLbWsnvN5FcHjpyLiTIyyEZICjnCmerusUnCXBEntAZLnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codingame/monaco-vscode-base-service-override": "4.3.2",
+                "@codingame/monaco-vscode-environment-service-override": "4.3.2",
+                "@codingame/monaco-vscode-extensions-service-override": "4.3.2",
+                "@codingame/monaco-vscode-files-service-override": "4.3.2",
+                "@codingame/monaco-vscode-host-service-override": "4.3.2",
+                "@codingame/monaco-vscode-layout-service-override": "4.3.2",
+                "@codingame/monaco-vscode-quickaccess-service-override": "4.3.2"
             }
         },
         "node_modules/ms": {
@@ -4488,12 +10868,13 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -5421,18 +11802,6 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/tinypool": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -6164,18 +12533,6 @@
                 "@esbuild/win32-x64": "0.27.2"
             }
         },
-        "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/vitest": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -6246,18 +12603,6 @@
                 "jsdom": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vitest/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vscode": {

--- a/package.json
+++ b/package.json
@@ -67,9 +67,13 @@
         "vscode": "npm:@codingame/monaco-vscode-api@3.2.3"
     },
     "overrides": {
-        "vscode": "npm:@codingame/monaco-vscode-api@3.2.3",
-        "@codingame/monaco-vscode-editor-api": "3.2.3",
-        "@codingame/monaco-vscode-keybindings-api": "3.2.3"
+        "monaco-editor-wrapper": {
+            "vscode": "$vscode",
+            "@codingame/monaco-vscode-api": "$vscode",
+            "@codingame/monaco-vscode-editor-api": "$monaco-editor",
+            "@codingame/monaco-vscode-editor-service-override": "$@codingame/monaco-vscode-editor-service-override",
+            "@codingame/monaco-vscode-keybindings-service-override": "$@codingame/monaco-vscode-keybindings-service-override"
+        }
     },
     "volta": {
         "node": "20.19.6",


### PR DESCRIPTION
Fixes the build error introduced with 9b35dfc79f525163f65850a4d25a8451b62fa7ce on nix by correctly overriding the version, but dunno if everything still works :P